### PR TITLE
Extending functionality for the registerStories function

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -5,6 +5,7 @@ import {
   getComponentNameFromFilename
 } from "./util";
 
+export default function registerStories(req, fileName, sbInstance, plugins, decorators) {
   const {
     action,
     withKnobs,
@@ -58,6 +59,10 @@ import {
         }
       };
     };
+    decorators.forEach((decor) => {
+      storiesOf.addDecorator(decor);
+    })
+    story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 

--- a/src/register.js
+++ b/src/register.js
@@ -5,7 +5,7 @@ import {
   getComponentNameFromFilename
 } from "./util";
 
-export default function registerStories({req, fileName, sbInstance, plugins, decorators, storyOptions}) {
+export default function registerStories({req, fileName, storiesOf, plugins, decorators, storyOptions}) {
   const {
     action,
     withKnobs,
@@ -29,7 +29,7 @@ export default function registerStories({req, fileName, sbInstance, plugins, dec
     componentConfig.__stories || componentConfig.default.__stories;
   if (!stories) return;
   stories.forEach(story => {
-    const storiesOf = sbInstance(story.group || "vue-storybook", module);
+    const storiesOfInstance = storiesOf(story.group || "vue-storybook", module);
     const componentFunc = () => {
       let data = story.knobs ?
         parseKnobsObject(story.knobs, {
@@ -61,13 +61,13 @@ export default function registerStories({req, fileName, sbInstance, plugins, dec
     };
     if(decorators){
     decorators.forEach((decor) => {
-      storiesOf.addDecorator(decor);
+        storiesOfInstance.addDecorator(decor);
       });
     }
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
 
-    storiesOf.add(story.name, componentFunc, {
+    storiesOfInstance.add(story.name, componentFunc, {
       notes: story.notes,
       ...storyOptions
     });

--- a/src/register.js
+++ b/src/register.js
@@ -5,7 +5,7 @@ import {
   getComponentNameFromFilename
 } from "./util";
 
-export default function registerStories(req, fileName, sbInstance, plugins, decorators) {
+export default function registerStories(req, fileName, sbInstance, plugins, decorators, storyOptions) {
   const {
     action,
     withKnobs,
@@ -67,7 +67,8 @@ export default function registerStories(req, fileName, sbInstance, plugins, deco
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
     storiesOf.add(story.name, componentFunc, {
-      notes: story.notes
+      notes: story.notes,
+      ...storyOptions
     });
   });
 }

--- a/src/register.js
+++ b/src/register.js
@@ -5,8 +5,22 @@ import {
   getComponentNameFromFilename
 } from "./util";
 
-export default function registerStories(req, fileName, sbInstance, plugins) {
-  const { action, withKnobs, text, color, select, boolean } = plugins;
+  const {
+    action,
+    withKnobs,
+    text,
+    boolean,
+    number,
+    select,
+    color,
+    radios,
+    date,
+    files,
+    object,
+    array,
+    optionsKnob,
+    button
+  } = plugins;
   const componentConfig = req(fileName);
   const componentName = getComponentNameFromFilename(fileName);
 
@@ -16,14 +30,21 @@ export default function registerStories(req, fileName, sbInstance, plugins) {
   stories.forEach(story => {
     const storiesOf = sbInstance(story.group || "vue-storybook", module);
     const componentFunc = () => {
-      let data = story.knobs
-        ? parseKnobsObject(story.knobs, {
-            boolean,
+      let data = story.knobs ?
+        parseKnobsObject(story.knobs, {
             text,
+          boolean,
+          number,
             select,
-            color
-          })
-        : {};
+          color,
+          radios,
+          date,
+          files,
+          object,
+          array,
+          optionsKnob,
+          button
+        }) : {};
       return {
         components: {
           [componentName]: componentConfig.default || componentConfig

--- a/src/register.js
+++ b/src/register.js
@@ -5,7 +5,7 @@ import {
   getComponentNameFromFilename
 } from "./util";
 
-export default function registerStories(req, fileName, sbInstance, plugins, decorators, storyOptions) {
+export default function registerStories({req, fileName, sbInstance, plugins, decorators, storyOptions}) {
   const {
     action,
     withKnobs,

--- a/src/register.js
+++ b/src/register.js
@@ -64,7 +64,6 @@ export default function registerStories(req, fileName, sbInstance, plugins, deco
     })
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
-    story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
     storiesOf.add(story.name, componentFunc, {
       notes: story.notes,

--- a/src/register.js
+++ b/src/register.js
@@ -59,9 +59,11 @@ export default function registerStories(req, fileName, sbInstance, plugins, deco
         }
       };
     };
+    if(decorators){
     decorators.forEach((decor) => {
       storiesOf.addDecorator(decor);
-    })
+      });
+    }
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
 

--- a/src/util.js
+++ b/src/util.js
@@ -15,7 +15,7 @@ function camelCase(str) {
 }
 
 function parseKnobsObject(obj, plugins) {
-  return Function(`return ({text, boolean, select, color}) => (${obj})`)()(
+  return Function(`return ({ text, boolean, number, select, color, radios, date, files, object, array, optionsKnob, button }) => (${obj})`)()(
     plugins
   );
 }


### PR DESCRIPTION
Adds support for the full range of knobs to be used
Adds support for supplying decorators into the registerStories function.
Note: The way they are applied at the moment could be made for flexible as the user would have no control over what order they are applied in the overall chain of steps performed in the registerStories function. 
Adds support for applying storyOptions to all stories.
Note: There is also room for improvement with giving further flexibility to the way this is applied.

