### PR TITLE
Feature/readme support

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -66,10 +66,19 @@ export default function registerStories({req, fileName, sbInstance, plugins, dec
     }
     story.knobs ? storiesOf.addDecorator(withKnobs) : false;
 
+    var readmeOptions = storyOptions.readme;
+    var readmeContent = readmeOptions.singleFileComponentBlockEnabled ? componentConfig.default.__docs : componentConfig.default.readme;
+    var readmeConfiguration = {
+      sidebar: readmeOptions.displaySidebar ? readmeContent : '',
+      content: readmeOptions.displayContent ? readmeContent : '',
+    };
 
     storiesOf.add(story.name, componentFunc, {
       notes: story.notes,
-      ...storyOptions
+      ...storyOptions,
+      readme: {
+        ...readmeConfiguration
+      },
     });
   });
 }


### PR DESCRIPTION
Added support for readme addon integration and options.

This gives flexibility to users looking to use the block style <docs> readme in SFCs as well as the flexibility of providing a readme property on their stories.