### PR TITLE
Support Vue.extend

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -55,7 +55,10 @@ export default function registerStories(
   const component = req(fileName);
   const name = getComponentNameFromFilename(fileName);
 
-  const stories = component.__stories || component.default.__stories;
+  const stories =
+    component.__stories ||
+    component.default.__stories ||
+    (component.default.options || {}).__stories;
 
   if (!stories) return;
   stories.forEach(story =>


### PR DESCRIPTION
I found `__stories` in `component.default.options` when I used `export default Vue.extend(extendOptions)`.


[vue-loader/lib/runtime/componentNormalizer.js](https://github.com/vuejs/vue-loader/blob/master/lib/runtime/componentNormalizer.js#L17)
```js
  // Vue.extend constructor export interop
  var options = typeof scriptExports === 'function'
    ? scriptExports.options
    : scriptExports
```